### PR TITLE
Feat |  Add option to load storage from ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ trove init
 
 And [configure your storage](#storage) in `.trove.yml`.
 
+Optionally you can set up URL to your bucket using `TROVE_STORAGE_URL` env variable.
+
 ## Storage
 
 ### Amazon S3

--- a/lib/trove.rb
+++ b/lib/trove.rb
@@ -159,7 +159,7 @@ module Trove
 
     def storage
       @storage ||= begin
-        storage_url = config["storage"] || ENV.fetch('TROVE_STORAGE_URL', nil)
+        storage_url = config["storage"] || ENV.fetch("TROVE_STORAGE_URL", nil)
         raise "Missing storage" unless storage_url
 
         uri =

--- a/lib/trove.rb
+++ b/lib/trove.rb
@@ -159,11 +159,12 @@ module Trove
 
     def storage
       @storage ||= begin
-        raise "Missing storage" unless config["storage"]
+        storage_url = config["storage"] || ENV.fetch('TROVE_STORAGE_URL', nil)
+        raise "Missing storage" unless storage_url
 
         uri =
           begin
-            URI.parse(config["storage"])
+            URI.parse(storage_url)
           rescue URI::InvalidURIError => e
             raise "Invalid storage"
           end

--- a/lib/trove.rb
+++ b/lib/trove.rb
@@ -165,7 +165,7 @@ module Trove
         uri =
           begin
             URI.parse(storage_url)
-          rescue URI::InvalidURIError => e
+          rescue URI::InvalidURIError
             raise "Invalid storage"
           end
 
@@ -173,7 +173,7 @@ module Trove
         when "s3"
           Storage::S3.new(
             bucket: uri.host,
-            prefix: uri.path[1..-1]
+            prefix: uri.path[1..]
           )
         else
           raise "Invalid storage provider: #{uri.scheme}"

--- a/test/trove_test.rb
+++ b/test/trove_test.rb
@@ -12,6 +12,10 @@ class TroveTest < Minitest::Test
     end
   end
 
+  def teardown
+    ENV['TROVE_STORAGE_URL'] = nil
+  end
+
   def test_works
     Trove.delete("test.txt")
 
@@ -29,6 +33,20 @@ class TroveTest < Minitest::Test
 
     File.write("trove/test.txt", "hello!")
 
+    Trove.pull("test.txt")
+
+    assert_equal "hello", File.read("trove/test.txt")
+  end
+
+  def test_storage_url_in_env
+    File.write ".trove.yml", <<~EOS
+      hello: world
+    EOS
+    ENV["TROVE_STORAGE_URL"] = "s3://#{ENV.fetch("S3_BUCKET")}/trove"
+
+    File.write("trove/test.txt", "hello")
+    Trove.push("test.txt")
+    File.unlink("trove/test.txt")
     Trove.pull("test.txt")
 
     assert_equal "hello", File.read("trove/test.txt")


### PR DESCRIPTION
This PR aims to add an option to load storage URL from ENV variables.

This is needed for complex deployment setups when depending on the environment, you might want to load models from different buckets.